### PR TITLE
Create the dashboard layout

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -15,17 +15,38 @@ champions_df = clean_and_preprocess_data(pd.DataFrame(champions))
 # Aggregate KPIs
 app_usage_kpis, champions_kpis = aggregate_kpis(users_df, champions_df)
 
-st.write('Employees')
-st.write(employees)
+# Key Metrics Cards
+total_employees = len(employees)
+active_users = len(users_df)
+total_champions = len(champions_df)
+total_locations = len(set([employee['Location'] for employee in employees]))
 
-st.write('App Users')
-st.write(users_df)
+st.subheader('Key Metrics')
+col1, col2, col3, col4 = st.columns(4)
+col1.metric("Total Employees", total_employees)
+col2.metric("Active Users", active_users)
+col3.metric("Champions", total_champions)
+col4.metric("Locations", total_locations)
 
-st.write('Champions')
-st.write(champions_df)
+# Tabbed Interface
+tab1, tab2, tab3 = st.tabs(["Employees", "App Usage", "Champions"])
 
-st.write('App Usage KPIs')
-st.write(app_usage_kpis)
+with tab1:
+    st.subheader('Employees Distribution by Role')
+    role_distribution = pd.DataFrame(employees)['Role'].value_counts().reset_index()
+    role_distribution.columns = ['Role', 'Count']
+    st.bar_chart(role_distribution.set_index('Role'))
 
-st.write('Champions KPIs by Specialization')
-st.write(champions_kpis)
+    st.subheader('Average Age of Employees')
+    avg_age = pd.DataFrame(employees)['Age'].mean()
+    st.metric("Average Age", round(avg_age, 2))
+
+with tab2:
+    st.subheader('App Usage Metrics')
+    st.write('App Usage KPIs')
+    st.write(app_usage_kpis)
+
+with tab3:
+    st.subheader('Champions by Specialization')
+    st.write('Champions KPIs by Specialization')
+    st.write(champions_kpis)


### PR DESCRIPTION
Add key metrics cards and tabbed interface to the dashboard layout.

* **Key Metrics Cards**
  - Calculate and display total employees, active users, champions, and locations.
  - Use Streamlit columns to layout the metrics.

* **Tabbed Interface**
  - Create tabs for Employees, App Usage, and Champions.
  - In the Employees tab, display distribution by role and average age.
  - In the App Usage tab, display app usage KPIs.
  - In the Champions tab, display champions KPIs by specialization.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pranamg/MktgInsights?shareId=4046cc1f-44af-41f6-85e3-dd3b6d9d5fe9).