### PR TITLE
Save generated data to CSV files

### DIFF
--- a/data_generation.py
+++ b/data_generation.py
@@ -2,6 +2,7 @@ from faker import Faker
 import random
 import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
+import os
 
 fake = Faker()
 
@@ -18,6 +19,7 @@ def generate_employees(num_employees=1000):
             "Gender": random.choice(["Male", "Female", "Non-binary"])
         }
         employees.append(employee)
+    save_to_csv(employees, 'data/employees.csv')
     return employees
 
 def generate_app_users(employees, num_users=200):
@@ -34,6 +36,7 @@ def generate_app_users(employees, num_users=200):
             "Features Used": random.sample(["Feature A", "Feature B", "Feature C", "Feature D"], random.randint(1, 4))
         }
         users.append(user)
+    save_to_csv(users, 'data/app_users.csv')
     return users
 
 def generate_champions(users, num_champions=20):
@@ -48,6 +51,7 @@ def generate_champions(users, num_champions=20):
             "Specialization": random.choice(["Specialization A", "Specialization B", "Specialization C"])
         }
         champions.append(champion)
+    save_to_csv(champions, 'data/champions.csv')
     return champions
 
 def clean_and_preprocess_data(df):
@@ -77,3 +81,8 @@ def aggregate_kpis(users, champions):
     }).rename(columns={'Champion ID': 'Number of Champions'}).reset_index()
 
     return app_usage_kpis, champions_kpis
+
+def save_to_csv(data, filename):
+    df = pd.DataFrame(data)
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    df.to_csv(filename, index=False)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import pandas as pd
+import os
 from data_generation import generate_employees, generate_app_users, generate_champions, clean_and_preprocess_data, aggregate_kpis
 
 st.title('🎈 Marketing Strategy Dashboard')


### PR DESCRIPTION
Add functionality to save the output of data generation functions to CSV files.

* Import `os` and `pandas` modules in `data_generation.py`.
* Add `save_to_csv` function in `data_generation.py` to save data to CSV files.
* Call `save_to_csv` in `generate_employees`, `generate_app_users`, and `generate_champions` functions in `data_generation.py`.
* Import `os` module in `streamlit_app.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pranamg/MktgInsights?shareId=2e741be4-872f-4011-a8ad-7040b7c67bb4).